### PR TITLE
DO-1836: Switch RPCs back to deployments and create startup probe

### DIFF
--- a/charts/rpc/templates/deployment.yaml
+++ b/charts/rpc/templates/deployment.yaml
@@ -3,92 +3,92 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "rpc.fullname"  . }}
+  name: {{ include "rpc.fullname"  $ }}
   labels:
-    lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+    lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  $ }}
     lavanet.xyz/node_type: "rpc"
-    {{- include "rpc.labels" . | nindent 4 }}
+    {{- include "rpc.labels" $ | nindent 4 }}
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+      lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  $ }}
       lavanet.xyz/node_type: "rpc"
-      {{- include "rpc.selectorLabels" . | nindent 6 }}
+      {{- include "rpc.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with $.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+        lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  $ }}
         lavanet.xyz/node_type: "rpc"
-        {{- include "rpc.selectorLabels" . | nindent 8 }}
+        {{- include "rpc.selectorLabels" $ | nindent 8 }}
     spec:
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- if $.Values.serviceAccountName }}
+      serviceAccountName: {{ $.Values.serviceAccountName }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.snapshot.enabled }}
+        {{- toYaml $.Values.podSecurityContext | nindent 8 }}
+      {{- if $.Values.snapshot.enabled }}
       initContainers:
         - name: download-and-install-snapshot
-          image: "{{ .Values.snapshot.image.repository }}:{{ .Values.snapshot.image.tag }}"
-          imagePullPolicy: {{ .Values.snapshot.image.pullPolicy }}
-          command: {{ tpl (.Values.snapshot.command | toYaml | nindent 12) . }}
+          image: "{{ $.Values.snapshot.image.repository }}:{{ $.Values.snapshot.image.tag }}"
+          imagePullPolicy: {{ $.Values.snapshot.image.pullPolicy }}
+          command: {{ tpl ($.Values.snapshot.command | toYaml | nindent 12) . }}
           volumeMounts:
             - name: data-volume
-              mountPath: {{ .Values.dataDir }}
+              mountPath: {{ $.Values.dataDir }}
       {{- end }}
       containers:
-        - name: {{ include "rpc.fullname"  . }}
+        - name: {{ include "rpc.fullname"  $ }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           volumeMounts:
-          {{- range .Values.extraSecretMounts }}
+          {{- range $.Values.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
-          {{- range .Values.extraConfigMounts }}
+          {{- range $.Values.extraConfigMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
             - name: data-volume
-              mountPath: {{ .Values.dataDir }}
-              subPath: "{{ .Values.persistentVolume.subPath }}"
-          {{- with .Values.envFrom }}
+              mountPath: {{ $.Values.dataDir }}
+              subPath: "{{ $.Values.persistentVolume.subPath }}"
+          {{- with $.Values.envFrom }}
           envFrom: 
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env: 
             - name: DATA_DIR
-              value: {{ .Values.dataDir }} 
+              value: {{ $.Values.dataDir }} 
             - name: LOG_LEVEL
-              value: {{ .Values.logLevel }}
-          {{- with .Values.env }}
+              value: {{ $.Values.logLevel }}
+          {{- with $.Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-          {{- range .Values.ports }}
+          {{- range $.Values.ports }}
             - name: {{ .name }}
               containerPort: {{ .number }}
               protocol: {{ .protocol }}
           {{- end }}
-          {{- if .Values.command }}
-          {{- with .Values.commmand.name }}
+          {{- if $.Values.command }}
+          {{- with $.Values.commmand.name }}
           command: 
             - {{ . | quote }}
           {{- end }}
-          {{- with .Values.commmand.args }}
+          {{- with $.Values.commmand.args }}
           args:
             {{- toYaml . | nindent 12 -}}
           {{- end }}
@@ -97,36 +97,36 @@ spec:
           command: ["run"]
           args: [ ]
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with $.Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{ if .Values.livenessProbe.enabled }}
+          {{ if $.Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- toYaml (unset .Values.livenessProbe "enabled") | nindent 12 }}
+            {{- toYaml (unset $.Values.livenessProbe "enabled") | nindent 12 }}
           {{- end }}
-          {{ if .Values.readinessProbe.enabled }}
+          {{ if $.Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- toYaml (unset .Values.readinessProbe "enabled") | nindent 12 }}
+            {{- toYaml (unset $.Values.readinessProbe "enabled") | nindent 12 }}
           {{ end }}
-      {{- with .Values.nodeSelector }}
+      {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with $.Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        {{- range .Values.extraSecretMounts }}
+        {{- range $.Values.extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -134,7 +134,7 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
-        {{- range .Values.extraConfigMounts }}
+        {{- range $.Values.extraConfigMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -143,13 +143,13 @@ spec:
             {{- end }}
         {{- end }}
         - name: data-volume
-        {{- if .Values.persistentVolume.enabled }}
+        {{- if $.Values.persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }} {{- include "rpc.fullname"  . }}-data-volume-pvc-{{$i}} {{- end }}
+            claimName: {{ if $.Values.persistentVolume.existingClaim }}{{ $.Values.persistentVolume.existingClaim }}{{- else }} {{- include "rpc.fullname"  $ }}-data-volume-pvc-{{$i}} {{- end }}
         {{- else }}
           emptyDir:
-          {{- if .Values.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
+          {{- if $.Values.emptyDir.sizeLimit }}
+            sizeLimit: {{ $.Values.emptyDir.sizeLimit }}
           {{- else }}
             {}
           {{- end -}}

--- a/charts/rpc/templates/deployment.yaml
+++ b/charts/rpc/templates/deployment.yaml
@@ -1,0 +1,157 @@
+{{- range $i := until (int .Values.replicaCount) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rpc.fullname"  . }}
+  labels:
+    lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+    lavanet.xyz/node_type: "rpc"
+    {{- include "rpc.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+      lavanet.xyz/node_type: "rpc"
+      {{- include "rpc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        lavanet.xyz/node_moniker:  {{ include "rpc.moniker"  . }}
+        lavanet.xyz/node_type: "rpc"
+        {{- include "rpc.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.snapshot.enabled }}
+      initContainers:
+        - name: download-and-install-snapshot
+          image: "{{ .Values.snapshot.image.repository }}:{{ .Values.snapshot.image.tag }}"
+          imagePullPolicy: {{ .Values.snapshot.image.pullPolicy }}
+          command: {{ tpl (.Values.snapshot.command | toYaml | nindent 12) . }}
+          volumeMounts:
+            - name: data-volume
+              mountPath: {{ .Values.dataDir }}
+      {{- end }}
+      containers:
+        - name: {{ include "rpc.fullname"  . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+          {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.extraConfigMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+            - name: data-volume
+              mountPath: {{ .Values.dataDir }}
+              subPath: "{{ .Values.persistentVolume.subPath }}"
+          {{- with .Values.envFrom }}
+          envFrom: 
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env: 
+            - name: DATA_DIR
+              value: {{ .Values.dataDir }} 
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
+          {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+          {{- range .Values.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .number }}
+              protocol: {{ .protocol }}
+          {{- end }}
+          {{- if .Values.command }}
+          {{- with .Values.commmand.name }}
+          command: 
+            - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.commmand.args }}
+          args:
+            {{- toYaml . | nindent 12 -}}
+          {{- end }}
+          # default command
+          {{- else }}
+          command: ["run"]
+          args: [ ]
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{ if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- toYaml (unset .Values.livenessProbe "enabled") | nindent 12 }}
+          {{- end }}
+          {{ if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- toYaml (unset .Values.readinessProbe "enabled") | nindent 12 }}
+          {{ end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- with .optional }}
+            optional: {{ . }}
+            {{- end }}
+        {{- end }}
+        {{- range .Values.extraConfigMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- with .optional }}
+            optional: {{ . }}
+            {{- end }}
+        {{- end }}
+        - name: data-volume
+        {{- if .Values.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }} {{- include "rpc.fullname"  . }}-data-volume-pvc-{{$i}} {{- end }}
+        {{- else }}
+          emptyDir:
+          {{- if .Values.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
+          {{- else }}
+            {}
+          {{- end -}}
+        {{- end -}}
+{{- end -}}

--- a/charts/rpc/templates/deployment.yaml
+++ b/charts/rpc/templates/deployment.yaml
@@ -109,6 +109,18 @@ spec:
           readinessProbe:
             {{- toYaml (unset $.Values.readinessProbe "enabled") | nindent 12 }}
           {{ end }}
+          {{ if $.Values.startupProbe.enabled }}
+          startupProbe:
+            {{- toYaml (unset $.Values.startupProbe "enabled") | nindent 12 }}
+          {{ else if $.Values.simpleStartupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /block?height={{ $.Values.simpleStartupProbe.height }}
+              port: 26657
+            # check every two minutes for ~24 hours
+            failureThreshold: 40000
+            periodSeconds: 120
+          {{ end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rpc/templates/pvc.yaml
+++ b/charts/rpc/templates/pvc.yaml
@@ -5,35 +5,35 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "rpc.fullname"  . }}-data-volume-pvc-{{ $i }}}
-  {{- if .Values.persistentVolume.annotations }}
+  name: {{ include "rpc.fullname" $ }}-data-volume-pvc-{{ $i }}}
+  {{- if $.Values.persistentVolume.annotations }}
   annotations:
-{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+{{ toYaml $.Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "rpc.labels" . | nindent 4 }}
+    {{- include "rpc.labels" $ | nindent 4 }}
 spec:
   accessModes:
-{{ toYaml .Values.persistentVolume.accessModes | indent 4 }}
-{{- if .Values.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+{{ toYaml $.Values.persistentVolume.accessModes | indent 4 }}
+{{- if $.Values.persistentVolume.storageClass }}
+{{- if (eq "-" $.Values.persistentVolume.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+  storageClassName: "{{ $.Values.persistentVolume.storageClass }}"
 {{- end }}
 {{- end }}
-{{- if .Values.persistentVolume.volumeBindingMode }}
-  volumeBindingMode: "{{ .Values.persistentVolume.volumeBindingMode }}"
+{{- if $.Values.persistentVolume.volumeBindingMode }}
+  volumeBindingMode: "{{ $.Values.persistentVolume.volumeBindingMode }}"
 {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.storageSize }}"
-{{- if .Values.persistentVolume.selector }}
+      storage: "{{ $.Values.storageSize }}"
+{{- if $.Values.persistentVolume.selector }}
   selector:
-  {{- toYaml .Values.persistentVolume.selector | nindent 4 }}
+  {{- toYaml $.Values.persistentVolume.selector | nindent 4 }}
 {{- end -}}
-{{- if .Values.persistentVolume.volumeName }}
-  volumeName: "{{ .Values.persistentVolume.volumeName }}"
+{{- if $.Values.persistentVolume.volumeName }}
+  volumeName: "{{ $.Values.persistentVolume.volumeName }}"
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/rpc/templates/pvc.yaml
+++ b/charts/rpc/templates/pvc.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.persistentVolume.enabled -}}
+{{- if not .Values.persistentVolume.existingClaim -}}
+{{- range $i := until (int .Values.replicaCount) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rpc.fullname"  . }}-data-volume-pvc-{{ $i }}}
+  {{- if .Values.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "rpc.labels" . | nindent 4 }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistentVolume.accessModes | indent 4 }}
+{{- if .Values.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
+{{- if .Values.persistentVolume.volumeBindingMode }}
+  volumeBindingMode: "{{ .Values.persistentVolume.volumeBindingMode }}"
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.storageSize }}"
+{{- if .Values.persistentVolume.selector }}
+  selector:
+  {{- toYaml .Values.persistentVolume.selector | nindent 4 }}
+{{- end -}}
+{{- if .Values.persistentVolume.volumeName }}
+  volumeName: "{{ .Values.persistentVolume.volumeName }}"
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rpc/templates/statefulset.yaml
+++ b/charts/rpc/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.useStatefulSet }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -145,3 +146,4 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
+{{- end -}}

--- a/charts/rpc/values.yaml
+++ b/charts/rpc/values.yaml
@@ -261,14 +261,14 @@ livenessProbe:
   # successThreshold: 1
   # failureThreshold: 3
 
-# startup probe:
+# startup probe
+# start only when the rpc is at this block
 simpleStartupProbe:
   enabled: false
-  # start only when the rpc is at this block
   height: 529900
 
 startupProbe:
-  enabled: true
+  enabled: false
 
 imagePullSecrets: []
 nodeSelector: {}

--- a/charts/rpc/values.yaml
+++ b/charts/rpc/values.yaml
@@ -261,6 +261,15 @@ livenessProbe:
   # successThreshold: 1
   # failureThreshold: 3
 
+# startup probe:
+simpleStartupProbe:
+  enabled: false
+  # start only when the rpc is at this block
+  height: 529900
+
+startupProbe:
+  enabled: true
+
 imagePullSecrets: []
 nodeSelector: {}
 tolerations: []

--- a/charts/rpc/values.yaml
+++ b/charts/rpc/values.yaml
@@ -265,7 +265,7 @@ livenessProbe:
 # start only when the rpc is at this block
 simpleStartupProbe:
   enabled: false
-  height: 529900
+  height: 542000
 
 startupProbe:
   enabled: false

--- a/charts/rpc/values.yaml
+++ b/charts/rpc/values.yaml
@@ -153,6 +153,63 @@ service:
   # override .Values.ports with these values
   ports: null
 
+# setup pvc for the node
+persistentVolume:
+  ## If true, will create/use a Persistent Volume Claim
+  ## If false, use emptyDir
+  enabled: true
+
+  ## Must match those of existing PV or dynamic provisioner
+  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  accessModes:
+    - ReadWriteOnce
+
+  ## Persistent Volume labels
+  labels: {}
+
+  ## Persistent Volume annotations
+  annotations: {}
+
+  ## Persistent Volume existing claim name
+  ## Requires persistentVolume.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  existingClaim: ""
+
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  storageClass: null
+
+  ## Subdirectory of data Persistent Volume to mount
+  ## Useful if the volume's root directory is not empty
+  subPath: ""
+
+  ## Persistent Volume Claim Selector
+  ## Useful if Persistent Volumes have been provisioned in advance
+  ## Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+  selector: null
+  ## ex: 
+  # selector:
+  #  matchLabels:
+  #    release: "stable"
+  #  matchExpressions:
+  #    - { key: environment, operator: In, values: [ dev ] }
+
+  ## Persistent Volume Name
+  ## Useful if Persistent Volumes have been provisioned in advance and you want to use a specific one
+  ##
+  volumeName: null
+  # volumeName: ""
+
+  volumeBindingMode: null
+
+  emptyDir:
+    ## emptyDir volume size limit
+    sizeLimit: ""
+
 # mount secrets as files, useful for mounting key file
 extraSecretMounts: []
   # - name: node-private-key

--- a/charts/rpc/values.yaml
+++ b/charts/rpc/values.yaml
@@ -9,7 +9,7 @@ nameOverride: null
 moniker: null
 
 # number of nodes to run
-replicasCount: 1
+replicaCount: 1
 
 # chain id of lava
 chainId: "lava-testnet-2"
@@ -211,3 +211,6 @@ affinity: {}
 podAnnotations: {}
 podSecurityContext: {}
 securityContext: {}
+
+# backwards compatibility, remove if no one is using statefulsets
+useStatefulSet: false


### PR DESCRIPTION
@lavanet-nikola Made changes we talked about this morning. 

- Default to using `Deployment` instead of `StatefulSet`
- For each `replicaCount` we create a new `PVC` and a new `pod`
- Added`simpleStartupProbe`, which uses a predefined block number (idea being whoever launches the RPC can pick a good predefined block number in the future, maybe 24 hours in advance, or 30 mins in advance if using a snapshot)

**Later**

In another PR I can work on more logic-heavy `startup` and `liveness` probes, using multiple other RPCs.