### PR TITLE
DO-1993: Add metrics-port

### DIFF
--- a/charts/consumer/templates/config.yaml
+++ b/charts/consumer/templates/config.yaml
@@ -19,4 +19,5 @@ data:
         api-interface: {{ (index $endpoint "api-interface")  }}
         network-address: "0.0.0.0:{{ add 5000 $i }}"
       {{- end }}
+    metrics-listen-address: ":{{.Values.metrics-port}}"
 {{- end -}}

--- a/charts/consumer/values.yaml
+++ b/charts/consumer/values.yaml
@@ -43,6 +43,7 @@ key:
 #     api-interface: tendermintrpc
 #   - chain-id: COS5
 #     api-interface: grpc
+# metrics-port: 20020
 endpoints: []
 
 # use lavavisor or control versions directly with docker images


### PR DESCRIPTION
Add metrics port general to all the deployment - reduces monitoring complexity with Prometheus