### PR TITLE
Fix provider metrics

### DIFF
--- a/charts/provider/templates/deployment.yaml
+++ b/charts/provider/templates/deployment.yaml
@@ -160,20 +160,22 @@ spec:
             "{{ .Values.persistentVolume.mountPath }}",
             "--node", "{{ $rpcNodeUrl }}",
             "--chain-id", "{{ .Values.chainId }}",
-            "--log_level", "{{ .Values.logLevel }}"
+            "--log_level", "{{ .Values.logLevel }}",
+            "--metrics-listen-address", "0.0.0.0:{{ .Values.metrics.port }}"
           ]
           {{- else }}
           command: ["lavap"]
           args: [
-            "rpcprovider", "{{ $configFilePath }}", 
+            "rpcprovider", "{{ $configFilePath }}",
             "--from", "{{- include "provider.keyname" . }}",
-            "--home",  "{{ .Values.persistentVolume.mountPath }}", 
+            "--home",  "{{ .Values.persistentVolume.mountPath }}",
             "--keyring-backend", "test",
             "--keyring-dir",  "{{ .Values.persistentVolume.mountPath }}",
             "--geolocation", "{{.Values.geolocation}}",
             "--node", "{{ $rpcNodeUrl }}",
             "--chain-id", "{{.Values.chainId}}",
-            "--log_level", "{{ .Values.logLevel }}"
+            "--log_level", "{{ .Values.logLevel }}",
+            "--metrics-listen-address", "0.0.0.0:{{ .Values.metrics.port }}"
           ]
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Provider probes were broken as metrics were disabled

```
 Normal   Pulled     4m27s                  kubelet            Container image "us-central1-docker.pkg.dev/lavanet-public/images/lava-provider:v1.2.3" already present on machine
  Normal   Created    4m27s                  kubelet            Created container lava-node-01-lava-provider
  Normal   Started    4m27s                  kubelet            Started container lava-node-01-lava-provider
  Warning  Unhealthy  2m8s (x10 over 3m38s)  kubelet            Readiness probe failed:
  Warning  Unhealthy  2m3s (x9 over 3m23s)   kubelet            Liveness probe failed: Get "http://10.100.27.144:2025/metrics/overall-health": dial tcp 10.100.27.144:2025: connect: connection refused
```