### PR TITLE
Improve monitoring configurability

### DIFF
--- a/charts/provider/templates/deployment.yaml
+++ b/charts/provider/templates/deployment.yaml
@@ -161,7 +161,9 @@ spec:
             "--node", "{{ $rpcNodeUrl }}",
             "--chain-id", "{{ .Values.chainId }}",
             "--log_level", "{{ .Values.logLevel }}",
+            {{- if .Values.metrics.enabled }}
             "--metrics-listen-address", "0.0.0.0:{{ .Values.metrics.port }}"
+            {{- end }}
           ]
           {{- else }}
           command: ["lavap"]
@@ -175,7 +177,9 @@ spec:
             "--node", "{{ $rpcNodeUrl }}",
             "--chain-id", "{{.Values.chainId}}",
             "--log_level", "{{ .Values.logLevel }}",
+            {{- if .Values.metrics.enabled }}
             "--metrics-listen-address", "0.0.0.0:{{ .Values.metrics.port }}"
+            {{- end }}
           ]
           {{- end }}
           {{- end }}

--- a/charts/provider/templates/deployment.yaml
+++ b/charts/provider/templates/deployment.yaml
@@ -132,6 +132,11 @@ spec:
             - name: {{ .Values.port.name }}
               containerPort: {{ .Values.port.number }}
               protocol: {{ .Values.port.protocol }}
+            {{ if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{ end }}
           {{- if .Values.command }}
           {{- with .Values.command.name }}
           command: 

--- a/charts/provider/templates/service.yaml
+++ b/charts/provider/templates/service.yaml
@@ -27,6 +27,12 @@ spec:
       port: {{ .Values.port.number }}
       protocol: {{ .Values.port.protocol }}
       targetPort: {{ .Values.port.name }}
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: metrics
+    {{- end }}
   {{- end }}
   selector:
     lavanet.xyz/node_moniker:  {{ include "provider.moniker"  . }}

--- a/charts/provider/templates/servicemonitor.yaml
+++ b/charts/provider/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "provider.fullname"  . }}
+  labels:
+    lavanet.xyz/node_moniker:  {{ include "provider.moniker"  . }}
+    lavanet.xyz/node_type: "provider"
+    {{- include "provider.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      lavanet.xyz/node_moniker:  {{ include "provider.moniker"  . }}
+      lavanet.xyz/node_type: "provider"
+      {{- include "provider.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: {{ .Values.serviceMonitor.path }}
+{{- end }}

--- a/charts/provider/values.yaml
+++ b/charts/provider/values.yaml
@@ -143,6 +143,7 @@ port:
 
 # metrics port to expose the node on
 metrics:
+  enabled: true
   port: 2025
 
 # set service account name

--- a/charts/provider/values.yaml
+++ b/charts/provider/values.yaml
@@ -146,6 +146,12 @@ metrics:
   enabled: true
   port: 2025
 
+# enable service monitor for prometheus
+serviceMonitor:
+  enabled: false
+  interval: 15s
+  path: /metrics
+
 # set service account name
 serviceAccountName: null
 

--- a/charts/provider/values.yaml
+++ b/charts/provider/values.yaml
@@ -5,6 +5,11 @@ logLevel: "warn"
 fullnameOverride: null
 nameOverride: null
 
+# REQUIRED: The external hostname for the provider
+## example
+# endpoint: "provider.lavanet.xyz"
+endpoint: ""
+
 # provider node moniker, will default to the fullname
 moniker: null
 


### PR DESCRIPTION
This PR aims to improve monitoring configurability in the chart by:
- Allowing users to toggle metrics, adding the necessary port to the deployment and expose it via the service.
- Allowing users to enable a ServiceMonitor resource for Prometheus to scrape the metrics endpoint via the service.

I've also added a missing `endpoints` attribute in the values file, as it is required by the chart.